### PR TITLE
Refactor the time now

### DIFF
--- a/internal/color/output.go
+++ b/internal/color/output.go
@@ -1,0 +1,43 @@
+package color
+
+import (
+	"fmt"
+	"strings"
+)
+
+type color int
+
+const reset string = "\033[0m"
+
+const (
+	Black color = iota + 30
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+)
+
+const (
+	HiBlack color = iota + 90
+	HiRed
+	HiGreen
+	HiYellow
+	HiBlue
+	HiMagenta
+	HiCyan
+	HiWhite
+)
+
+func (c color) format() string {
+	return fmt.Sprintf("\033[%dm", c)
+}
+
+func PrintlnColor(message string, color color) {
+	if !strings.HasSuffix(message, "\n") {
+		message += "\n"
+	}
+	fmt.Printf("%s%s%s", color.format(), message, reset)
+}

--- a/time/model.go
+++ b/time/model.go
@@ -1,15 +1,12 @@
 package swisstime
 
 import (
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/go-playground/validator/v10"
+	"github.com/beemensameh/swissknife-tools/internal/color"
 )
 
-var timeFromat = map[int]string{
+var timeFormat = map[uint]string{
 	1:  time.ANSIC,
 	2:  time.UnixDate,
 	3:  time.RubyDate,
@@ -27,29 +24,19 @@ var timeFromat = map[int]string{
 	15: time.StampNano,
 }
 
-func newTimeFormat(format int) string {
-	return timeFromat[format]
+func newTimeFormat(format uint) string {
+	return timeFormat[format]
 }
 
 type TimeCLI struct {
 	Format   string
 	Update   bool
-	Interval int `validate:"omitempty,gte=1"`
+	Interval uint
 }
 
-func (uuidCLI *TimeCLI) validated() error {
-	validate := validator.New()
-
-	err := validate.Struct(uuidCLI)
-	if err != nil {
-		var errorMessages []string
-
-		for _, err := range err.(validator.ValidationErrors) {
-			errorMessages = append(errorMessages, fmt.Sprintf("%s should be %s (%s)", err.Field(), err.Tag(), err.Param()))
-		}
-
-		return errors.New(strings.Join(errorMessages, "\n"))
+func (timeCLI *TimeCLI) validated() {
+	if timeCLI.Interval <= 0 && timeCLI.Update {
+		color.PrintlnColor("Interval should be large that 0. Change interval to 1.", color.Yellow)
+		timeCLI.Interval = 1
 	}
-
-	return nil
 }

--- a/time/time.go
+++ b/time/time.go
@@ -11,7 +11,7 @@ const displayStyle = "\r%s"
 
 var TimeNowCmd = &cli.Command{
 	Name:    "time:now",
-	Usage:   "Get time now and update very i second and with f format",
+	Usage:   "Get time now and update every i second with f format",
 	Aliases: []string{"time:nw"},
 	Action:  TimeNowAction,
 	Flags: []cli.Flag{
@@ -37,16 +37,14 @@ var TimeNowCmd = &cli.Command{
 
 func TimeNowAction(cliContext *cli.Context) error {
 	return timeNow(&TimeCLI{
-		Format:   newTimeFormat(cliContext.Int("format")),
+		Format:   newTimeFormat(cliContext.Uint("format")),
 		Update:   cliContext.Bool("update"),
-		Interval: cliContext.Int("interval"),
+		Interval: cliContext.Uint("interval"),
 	})
 }
 
 func timeNow(timeCLI *TimeCLI) error {
-	if err := timeCLI.validated(); err != nil {
-		return err
-	}
+	timeCLI.validated()
 
 	if timeCLI.Update {
 		ticker := time.NewTicker(time.Duration(timeCLI.Interval) * time.Second)

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,7 +1,6 @@
 package swisstime
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -11,22 +10,18 @@ import (
 
 func TestTimeNow(t *testing.T) {
 	testCases := map[string]struct {
-		timeCLI       TimeCLI
-		isFail        bool
-		expectedError error
+		timeCLI TimeCLI
 	}{
 		"Should return time now successfully": {
 			timeCLI: TimeCLI{
 				Format: newTimeFormat(0),
 			},
 		},
-		"Should return validation error": {
+		"Should return time now even the interval is negative or zero": {
 			timeCLI: TimeCLI{
 				Format:   newTimeFormat(1),
-				Interval: -5,
+				Interval: 0,
 			},
-			isFail:        true,
-			expectedError: errors.New("Interval should be gte (1)"),
 		},
 	}
 
@@ -36,12 +31,6 @@ func TestTimeNow(t *testing.T) {
 			t.Parallel()
 
 			err := timeNow(&tc.timeCLI)
-
-			if tc.isFail {
-				require.EqualError(t, err, tc.expectedError.Error())
-				return
-			}
-
 			require.Nil(t, err)
 		})
 	}
@@ -63,12 +52,12 @@ func TestDisplayTime(t *testing.T) {
 		},
 	}
 
-	for i, v := range timeFromat {
+	for i, v := range timeFormat {
 		testCases[fmt.Sprintf("Should return time with %s format, when pass format number %d", v, i)] = testCase{
 			timeCLI: TimeCLI{
 				Format: newTimeFormat(i),
 			},
-			expectedResult: fmt.Sprintf(displayStyle, testTime.Format(timeFromat[i])),
+			expectedResult: fmt.Sprintf(displayStyle, testTime.Format(timeFormat[i])),
 		}
 	}
 


### PR DESCRIPTION
## Description
1. Remove validator package from time cli.
2. Move the interval to accept uint instead of int.
3. Change the interval automatic to 1 if the value of interval less than or equal 0.
4. Add `PrintlnColor` to print the output with terminal colors