### PR TITLE
fix release version

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -32,7 +32,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-linux32
+              run: make tidy && make build-linux32 VERSION=$GITHUB_REF_NAME
     linux64:
         name: Check build linux-amd64 binary
         runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-linux64
+              run: make tidy && make build-linux64 VERSION=$GITHUB_REF_NAME
     win32:
         name: Check build win32 binary
         runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-win32
+              run: make tidy && make build-win32 VERSION=$GITHUB_REF_NAME
     win64:
         name: Check build win64 binary
         runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-win64
+              run: make tidy && make build-win64 VERSION=$GITHUB_REF_NAME
     macos:
         name: Check build macos binary
         runs-on: ubuntu-latest
@@ -76,4 +76,4 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-mac
+              run: make tidy && make build-mac VERSION=$GITHUB_REF_NAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
     push:
         tags:
-            - "v*"
+            - "*"
 
 jobs:
     linux32:
@@ -17,7 +17,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: build
-              run: make tidy && make build-linux32
+              run: make tidy && make build-linux32 VERSION=$GITHUB_REF_NAME
             - name: release
               uses: softprops/action-gh-release@v1
               with:
@@ -35,7 +35,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: build
-              run: make tidy && make build-linux64
+              run: make tidy && make build-linux64 VERSION=$GITHUB_REF_NAME
             - name: release
               uses: softprops/action-gh-release@v1
               with:
@@ -53,7 +53,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: build
-              run: make tidy && make build-win32
+              run: make tidy && make build-win32 VERSION=$GITHUB_REF_NAME
             - name: release
               uses: softprops/action-gh-release@v1
               with:
@@ -71,7 +71,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: build
-              run: make tidy && make build-win64
+              run: make tidy && make build-win64 VERSION=$GITHUB_REF_NAME
             - name: release
               uses: softprops/action-gh-release@v1
               with:
@@ -89,7 +89,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: build
-              run: make tidy && make build-mac
+              run: make tidy && make build-mac VERSION=$GITHUB_REF_NAME
             - name: release
               uses: softprops/action-gh-release@v1
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-linux32
+              run: make tidy && make build-linux32 VERSION=$GITHUB_REF_NAME
     linux64:
         name: Check build linux-amd64 binary
         runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-linux64
+              run: make tidy && make build-linux64 VERSION=$GITHUB_REF_NAME
     win32:
         name: Check build win32 binary
         runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-win32
+              run: make tidy && make build-win32 VERSION=$GITHUB_REF_NAME
     win64:
         name: Check build win64 binary
         runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-win64
+              run: make tidy && make build-win64 VERSION=$GITHUB_REF_NAME
     macos:
         name: Check build macos binary
         runs-on: ubuntu-latest
@@ -75,4 +75,4 @@ jobs:
               with:
                   go-version: 1.20.3
             - name: Check build
-              run: make tidy && make build-mac
+              run: make tidy && make build-mac VERSION=$GITHUB_REF_NAME


### PR DESCRIPTION
## Description
* Fix the version of build. When the GitHub action is building the binaries, it should take the tag that trigger the build action. But this doesn't happen until now.